### PR TITLE
fix(Savepoint): Fix multiple SQL syntax errors

### DIFF
--- a/sqalx.go
+++ b/sqalx.go
@@ -110,7 +110,7 @@ func (n node) Beginx() (Node, error) {
 	case n.savePointEnabled:
 		// already in a transaction: using savepoints
 		n.nested = true
-		// savepoints name must start with a char and cannot contain dash (-)
+		// savepoints name must start with a char and cannot contain dashes (-)
 		n.savePointID = "sp_" + strings.Replace(uuid.NewV1().String(), "-", "_", -1)
 		_, err = n.tx.Exec("SAVEPOINT " + n.savePointID)
 	default:


### PR DESCRIPTION
Hey,

`SAVEPOINT` does not support bindvars, and the name must follow strict rules to be valid (see comments in the PR).