### PR TITLE
Extracting transaction from a node

### DIFF
--- a/sqalx.go
+++ b/sqalx.go
@@ -188,6 +188,11 @@ func (n *node) Commit() error {
 	return nil
 }
 
+// Tx returns the underlying transaction.
+func (n *node) Tx() *sqlx.Tx {
+	return n.tx
+}
+
 // Option to configure sqalx
 type Option func(*node) error
 


### PR DESCRIPTION
This PR allows the user to fetch the underlying transaction so sqalx can be used with functions that require a `*sqlx.Tx`