### PR TITLE
Add context aware interfaces to Driver

### DIFF
--- a/sqalx.go
+++ b/sqalx.go
@@ -39,8 +39,11 @@ type Node interface {
 // and therefore is limited to the methods they have in common.
 type Driver interface {
 	sqlx.Execer
+	sqlx.ExecerContext
 	sqlx.Queryer
+	sqlx.QueryerContext
 	sqlx.Preparer
+	sqlx.PreparerContext
 	BindNamed(query string, arg interface{}) (string, []interface{}, error)
 	DriverName() string
 	Get(dest interface{}, query string, args ...interface{}) error


### PR DESCRIPTION
EDIT:
This PR allows using a `sqalx.Driver` as an `ExecerContext` etc. `Driver` is an interface that contains methods that are found in an `*sqlx.DB` and `*sqlx.Tx`. `ExecerContext`  and such were missing from the interface and this was preventing to use their respective methods from a `Driver`.