### PR TITLE
Allows savepoints without raising an exception

### DIFF
--- a/sqalx.go
+++ b/sqalx.go
@@ -14,10 +14,6 @@ var (
 	// ErrNotInTransaction is returned when using Commit
 	// outside of a transaction.
 	ErrNotInTransaction = errors.New("not in transaction")
-
-	// ErrIncompatibleOption is returned when using an option incompatible
-	// with the selected driver.
-	ErrIncompatibleOption = errors.New("incompatible option")
 )
 
 var uuids = fastuuid.MustNewGenerator()
@@ -215,9 +211,6 @@ type Option func(*node) error
 // SavePoint option enables PostgreSQL Savepoints for nested transactions.
 func SavePoint(enabled bool) Option {
 	return func(n *node) error {
-		if enabled && n.Driver.DriverName() != "postgres" {
-			return ErrIncompatibleOption
-		}
 		n.savePointEnabled = enabled
 		return nil
 	}

--- a/sqalx_test.go
+++ b/sqalx_test.go
@@ -40,10 +40,6 @@ func TestSqalxConnectMySQL(t *testing.T) {
 	}
 
 	testSqalxConnect(t, "mysql", dataSource)
-
-	node, err := sqalx.Connect("mysql", dataSource, sqalx.SavePoint(true))
-	require.Equal(t, sqalx.ErrIncompatibleOption, err)
-	require.Nil(t, node)
 }
 
 func testSqalxConnect(t *testing.T, driverName, dataSource string, options ...sqalx.Option) {


### PR DESCRIPTION
Hi @heetch,

thanks for the exciting package! 

I found one issue with it. It looks like `sqlite3` also supports [savepoints](https://www.sqlite.org/lang_transaction.html) for nested transactions. 

It would be better to let users decide for themselves whether to use this option or not without raising an error. In my case, I use [sqlhooks](https://github.com/gchaincl/sqlhooks), the driver's name is a random string and it makes it hard to verify that. 

Here is my PR that fixes that. Thank you!