### PR TITLE
Fix TestSqalxConnectMySQL failure on Mac with Apple Silicon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-sql-driver/mysql v1.6.0
+	github.com/go-sql-driver/mysql v1.7.0
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/lib/pq v1.10.4
 	github.com/mattn/go-sqlite3 v1.14.11

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
-github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
-github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.7.0 h1:ueSltNNllEqE3qcWBTD0iQd3IpL/6U+mJxLkazJ7YPc=
+github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/jmoiron/sqlx v1.3.4 h1:wv+0IJZfL5z0uZoUjlpKgHkgaFSYD+r9CfrXjEXsO7w=
 github.com/jmoiron/sqlx v1.3.4/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=


### PR DESCRIPTION
TestSqalxConnectMySQL was failing with the following messages, so I fixed it.

```
=== RUN   TestSqalxConnectMySQL
[mysql] 2023/01/05 22:08:27 packets.go:37: unexpected EOF
[mysql] 2023/01/05 22:08:27 packets.go:37: unexpected EOF
[mysql] 2023/01/05 22:08:27 packets.go:37: unexpected EOF
    sqalx_test.go:66:
                Error Trace:    sqalx_test.go:66
                                                        sqalx_test.go:57
                Error:          Received unexpected error:
                                driver: bad connection
                Test:           TestSqalxConnectMySQL
```

## Environment

MacBook Pro (14-inch, 2021)
Apple M1 Max 

macOS Monterey 12.6.1 (21G217)

## Confirmation

I modify `docker-compose.yml` for using mysql/mysql-server like the following and confirmed `make test` is passed.

```
    mysql:
#        image: mysql:8.0 # intel only
         image: mysql/mysql-server:8.0 # mac M1 preview
```

https://github.com/heetch/sqalx/blob/6756091cec6a958e4f4377968173470ebdffd194/docker-compose.yml#L13-L14